### PR TITLE
Auth

### DIFF
--- a/Internal/auth/auth.go
+++ b/Internal/auth/auth.go
@@ -1,0 +1,23 @@
+package auth
+
+type UserStore interface {
+	Validate(username, password string) bool
+}
+
+type InMemoryUserStore struct {
+	users map[string]string
+}
+
+func NewInMemoryUserStore() *InMemoryUserStore {
+	return &InMemoryUserStore{
+		users: map[string]string{
+			"admin": "adminpass",
+			"user":  "userpass",
+		},
+	}
+}
+
+func (s *InMemoryUserStore) Validate(username, password string) bool {
+	storedPass, ok := s.users[username]
+	return ok && storedPass == password
+}

--- a/Internal/cli/cli_utils.go
+++ b/Internal/cli/cli_utils.go
@@ -1,16 +1,13 @@
-
 package cli
-
 
 import (
 	"bufio"
 	"fmt"
 	"strconv"
-	"strings"
+	"strings" // Add this import
 
 	"todo/internal/manager"
 	"todo/internal/todo"
-
 )
 
 func GetTaskInput(scanner *bufio.Scanner) string {
@@ -65,6 +62,4 @@ func MarkTaskComplete(manager manager.TodoManager, scanner *bufio.Scanner) {
 			fmt.Printf("Task %d marked as completed!\n", taskID)
 		}
 	}
-
 }
-

--- a/Internal/http/handlers.go
+++ b/Internal/http/handlers.go
@@ -1,0 +1,128 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"todo/internal/manager"
+)
+
+type Handlers struct {
+	TodoManager manager.TodoManager
+}
+
+func (h *Handlers) handleTodos(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGetTodos(w, r)
+	case http.MethodPost:
+		h.handlePostTodo(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *Handlers) handleTodo(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 3 {
+		http.Error(w, "Invalid URL", http.StatusBadRequest)
+		return
+	}
+
+	id, err := strconv.Atoi(parts[2])
+	if err != nil {
+		http.Error(w, "Invalid task ID", http.StatusBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.handleGetTodo(w, r, id)
+	case http.MethodPut:
+		if len(parts) >= 4 && parts[3] == "complete" {
+			h.handlePutComplete(w, r, id)
+		} else {
+			http.Error(w, "Invalid URL", http.StatusBadRequest)
+		}
+	case http.MethodDelete:
+		h.handleDeleteTodo(w, r, id)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *Handlers) handleGetTodos(w http.ResponseWriter, r *http.Request) {
+	todos := h.TodoManager.GetAll()
+	respondJSON(w, todos)
+}
+
+func (h *Handlers) handlePostTodo(w http.ResponseWriter, r *http.Request) {
+	var requestBody struct {
+		Title string `json:"title"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	title := strings.TrimSpace(requestBody.Title)
+	if title == "" {
+		http.Error(w, "Title cannot be empty", http.StatusBadRequest)
+		return
+	}
+	if len(title) > 100 {
+		http.Error(w, "Title too long (max 100 characters)", http.StatusBadRequest)
+		return
+	}
+
+	todo, err := h.TodoManager.Add(title)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	respondJSON(w, todo, http.StatusCreated)
+}
+
+func (h *Handlers) handleGetTodo(w http.ResponseWriter, r *http.Request, id int) {
+	todo, err := h.TodoManager.Get(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	respondJSON(w, todo)
+}
+
+func (h *Handlers) handlePutComplete(w http.ResponseWriter, r *http.Request, id int) {
+	err := h.TodoManager.MarkComplete(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handlers) handleDeleteTodo(w http.ResponseWriter, r *http.Request, id int) {
+	err := h.TodoManager.Delete(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func respondJSON(w http.ResponseWriter, data interface{}, status ...int) {
+	w.Header().Set("Content-Type", "application/json")
+	statusCode := http.StatusOK
+	if len(status) > 0 {
+		statusCode = status[0]
+	}
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(data)
+}

--- a/Internal/http/middlewares.go
+++ b/Internal/http/middlewares.go
@@ -1,0 +1,28 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"todo/internal/auth"
+)
+
+func AuthMiddleware(store auth.UserStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			username, password, ok := r.BasicAuth()
+			if !ok || !store.Validate(username, password) {
+				w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), "username", username)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/Internal/http/server.go
+++ b/Internal/http/server.go
@@ -1,149 +1,38 @@
 package http
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"todo/internal/manager"
 )
 
 type Server struct {
 	TodoManager manager.TodoManager
+	router      *http.ServeMux
 }
 
 func NewServer(m manager.TodoManager) *Server {
-	return &Server{TodoManager: m}
-}
-
-func (s *Server) SetupRoutes() http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/todos", s.handleTodos)
-	mux.HandleFunc("/todos/", s.handleTodo)
-	return mux
-}
-
-func (s *Server) handleTodos(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		s.handleGetTodos(w, r)
-	case http.MethodPost:
-		s.handlePostTodo(w, r)
-	default:
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	return &Server{
+		TodoManager: m,
+		router:      http.NewServeMux(),
 	}
 }
 
-func (s *Server) handleTodo(w http.ResponseWriter, r *http.Request) {
-	parts := strings.Split(r.URL.Path, "/")
-	if len(parts) < 3 {
-		http.Error(w, "Invalid URL", http.StatusBadRequest)
-		return
-	}
+func (s *Server) SetupRoutes() {
+	handlers := &Handlers{TodoManager: s.TodoManager}
 
-	id, err := strconv.Atoi(parts[2])
-	if err != nil {
-		http.Error(w, "Invalid task ID", http.StatusBadRequest)
-		return
-	}
+	// Health check endpoint
+	s.router.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
 
-	switch r.Method {
-	case http.MethodGet:
-		s.handleGetTodo(w, r, id)
-	case http.MethodPut:
-		if len(parts) >= 4 && parts[3] == "complete" {
-			s.handlePutComplete(w, r, id)
-		} else {
-			http.Error(w, "Invalid URL", http.StatusBadRequest)
-		}
-	case http.MethodDelete:
-		s.handleDeleteTodo(w, r, id)
-	default:
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-	}
+	// Todo endpoints
+	s.router.HandleFunc("/todos", handlers.handleTodos)
+	s.router.HandleFunc("/todos/", handlers.handleTodo)
 }
 
-func (s *Server) handleGetTodos(w http.ResponseWriter, r *http.Request) {
-	todos := s.TodoManager.GetAll()
-	data, err := json.Marshal(todos)
-	if err != nil {
-		http.Error(w, "Error marshaling todos", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(data)
-}
-
-func (s *Server) handlePostTodo(w http.ResponseWriter, r *http.Request) {
-	var requestBody struct {
-		Title string `json:"title"`
-	}
-
-	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
-		http.Error(w, "Invalid request body", http.StatusBadRequest)
-		return
-	}
-
-	if requestBody.Title == "" {
-		http.Error(w, "Title cannot be empty", http.StatusBadRequest)
-		return
-	}
-
-	todo, err := s.TodoManager.Add(requestBody.Title)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	data, err := json.Marshal(todo)
-	if err != nil {
-		http.Error(w, "Error marshaling todo", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	w.Write(data)
-}
-
-func (s *Server) handleGetTodo(w http.ResponseWriter, r *http.Request, id int) {
-	todo, err := s.TodoManager.Get(id)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
-
-	data, err := json.Marshal(todo)
-	if err != nil {
-		http.Error(w, "Error marshaling todo", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(data)
-}
-
-func (s *Server) handlePutComplete(w http.ResponseWriter, r *http.Request, id int) {
-	err := s.TodoManager.MarkComplete(id)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "Task %d marked as complete", id)
-}
-
-func (s *Server) handleDeleteTodo(w http.ResponseWriter, r *http.Request, id int) {
-	err := s.TodoManager.Delete(id)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "Task %d deleted", id)
+// ServeHTTP implements http.Handler
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.router.ServeHTTP(w, r)
 }

--- a/Internal/middleware/middleware.go
+++ b/Internal/middleware/middleware.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+func Logging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %v", r.Method, r.URL.Path, time.Since(start))
+	})
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,21 +2,29 @@ package main
 
 import (
 	"fmt"
-	"log"
-	
-	stdhttp "net/http"
+	"net/http"
 
-	"todo/internal/http"
+	"todo/internal/auth"
+	myhttp "todo/internal/http"  // Renamed import to avoid conflict
+	"todo/internal/middleware"
 	"todo/internal/manager"
 )
 
 func main() {
 	tm := manager.NewInMemoryTodoManager()
-	server := http.NewServer(tm)
-	
-	stdhttp.Handle("/", server.SetupRoutes())
-	
+	server := myhttp.NewServer(tm)
+
+	userStore := auth.NewInMemoryUserStore()
+
+	server.SetupRoutes()
+
+	// Apply middleware
+	handler := middleware.Logging(server)
+	handler = myhttp.AuthMiddleware(userStore)(handler) // Correct reference to http.AuthMiddleware
+
+	http.Handle("/", handler)
+
 	port := ":8080"
 	fmt.Printf("Server starting on %s\n", port)
-	log.Fatal(stdhttp.ListenAndServe(port, nil))
+	http.ListenAndServe(port, nil)
 }


### PR DESCRIPTION
feat: Implemented Server-Side Features with Authentication

This commit introduces a fully functional REST API server with:

Middleware for logging requests
Basic HTTP authentication
In-memory user store for credentials
CRUD operations for todos with validation
Error handling and status codes

Key components:

Middleware Implementation (Logging, Authentication)
Todo Manager (In-memory storage with CRUD operations)

API Endpoints: Verified in postman

POST /todos (Create new todo)
GET /todos (List all todos)
PUT /todos/{id}/complete (Mark todo as complete)
DELETE /todos/{id} (Delete todo)